### PR TITLE
Add .editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+# EditorConfig Site:    http://editorconfig.org
+# EditorConfig Plugins: http://editorconfig.org/#download
+
+# top-most EditorConfig file
+root = true
+
+[*]
+
+# Unix-style newlines with a newline ending every file
+end_of_line = lf
+insert_final_newline = false
+
+# Set default charset
+charset = utf-8
+
+# Indent w/2 spaces. No tabs.
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
There's an interesting project here: http://editorconfig.org/ ... that
attempts to define some baseline editor settings that can be used across
many different code editors. See: http://editorconfig.org/#download

The purpose of integrating into shubox projects it to make sure we're
all working with the same assumptions and standards for things like:

* indentation (tabs v spaces)
* width of tab (x number of spaces)
* character encoding / charset
* newlines at end of file (or not)
* etc

I've noticed that some HTML files are indented with 4 character widths,
some with 2, some with tabs, some with spaces. It'd be beneficial to us
to agree with one and stick with it.

NOTE: this is a proposal in PR form. This is not a mandate.

@dperrera, what do you think?