### PR TITLE
Add analytics code to marketing site

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,12 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.5.0)
+    addressable (2.5.1)
       public_suffix (~> 2.0, >= 2.0.2)
     colorator (1.1.0)
-    ffi (1.9.14)
+    ffi (1.9.18)
     forwardable-extended (2.6.0)
-    jekyll (3.3.1)
+    jekyll (3.4.3)
       addressable (~> 2.4)
       colorator (~> 1.0)
       jekyll-sass-converter (~> 1.0)
@@ -17,13 +17,13 @@ GEM
       pathutil (~> 0.9)
       rouge (~> 1.7)
       safe_yaml (~> 1.0)
-    jekyll-feed (0.8.0)
+    jekyll-feed (0.9.2)
       jekyll (~> 3.3)
     jekyll-sass-converter (1.5.0)
       sass (~> 3.4)
     jekyll-watch (1.5.0)
       listen (~> 3.0, < 3.1)
-    kramdown (1.13.1)
+    kramdown (1.13.2)
     liquid (3.0.6)
     listen (3.0.8)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -31,9 +31,9 @@ GEM
     mercenary (0.3.6)
     pathutil (0.14.0)
       forwardable-extended (~> 2.6)
-    public_suffix (2.0.4)
+    public_suffix (2.0.5)
     rb-fsevent (0.9.8)
-    rb-inotify (0.9.7)
+    rb-inotify (0.9.8)
       ffi (>= 0.5.0)
     rouge (1.11.1)
     safe_yaml (1.0.4)
@@ -50,4 +50,4 @@ RUBY VERSION
    ruby 2.3.1p112
 
 BUNDLED WITH
-   1.13.4
+   1.13.6

--- a/src/jekyll/_config.yml
+++ b/src/jekyll/_config.yml
@@ -1,15 +1,17 @@
 # Site settings
-# These are used to personalize your new site. If you look in the HTML files,
-# you will see them accessed via {{ site.title }}, {{ site.email }}, and so on.
-# You can create any custom variable you would like, and they will be accessible
-# in the templates via {{ site.myvariable }}.
 title: shubox.io
 email: joel@shubox.io
 shuboxScriptId: "03457406"
 baseurl: ""    # the subpath of your site, e.g. /blog
 url: ""        # the base hostname & protocol for your site, e.g. http://example.com
 description: >
-  The easiest and fastest way for your web-app to upload images directly to Amazon S3
+  The easiest and fastest way for your web-app to
+  upload images directly to Amazon S3
+
+# Analytics settings
+fb_pixel: "1490231254348649"
+ga: "UA-80905075-3"
+mixpanel: "01357d729eae31357daebaf72ebb3cd6"
 
 # Site-wide defaults
 defaults:

--- a/src/jekyll/_includes/analytics.liquid
+++ b/src/jekyll/_includes/analytics.liquid
@@ -5,11 +5,7 @@ n.callMethod.apply(n,arguments):n.queue.push(arguments)};if(!f._fbq)f._fbq=n;
 n.push=n;n.loaded=!0;n.version='2.0';n.queue=[];t=b.createElement(e);t.async=!0;
 t.src=v;s=b.getElementsByTagName(e)[0];s.parentNode.insertBefore(t,s)}(window,
 document,'script','https://connect.facebook.net/en_US/fbevents.js');
-fbq(
-  'init',
-  '{{site.fb_pixel}}',
-  { em: 'insert_email_variable,' }
-);
+fbq('init', '{{site.fb_pixel}}');
 fbq('track', 'PageView');
 </script>
 <noscript><img height="1" width="1" style="display:none" src="https://www.facebook.com/tr?id={{site.fb_pixel}}&ev=PageView&noscript=1" /></noscript>

--- a/src/jekyll/_includes/analytics.liquid
+++ b/src/jekyll/_includes/analytics.liquid
@@ -1,0 +1,29 @@
+<!-- Facebook -->
+<script>
+!function(f,b,e,v,n,t,s){if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+n.callMethod.apply(n,arguments):n.queue.push(arguments)};if(!f._fbq)f._fbq=n;
+n.push=n;n.loaded=!0;n.version='2.0';n.queue=[];t=b.createElement(e);t.async=!0;
+t.src=v;s=b.getElementsByTagName(e)[0];s.parentNode.insertBefore(t,s)}(window,
+document,'script','https://connect.facebook.net/en_US/fbevents.js');
+fbq(
+  'init',
+  '{{site.fb_pixel}}',
+  { em: 'insert_email_variable,' }
+);
+fbq('track', 'PageView');
+</script>
+<noscript><img height="1" width="1" style="display:none" src="https://www.facebook.com/tr?id={{site.fb_pixel}}&ev=PageView&noscript=1" /></noscript>
+
+<!-- Google Analytics -->
+<script>
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga('create', '{{site.ga}}', 'auto');
+ga('send', 'pageview');
+</script>
+<script async src='https://www.google-analytics.com/analytics.js'></script>
+
+<!-- Mixpanel -->
+<script>(function(e,b){if(!b.__SV){var a,f,i,g;window.mixpanel=b;b._i=[];b.init=function(a,e,d){function f(b,h){var a=h.split(".");2==a.length&&(b=b[a[0]],h=a[1]);b[h]=function(){b.push([h].concat(Array.prototype.slice.call(arguments,0)))}}var c=b;"undefined"!==typeof d?c=b[d]=[]:d="mixpanel";c.people=c.people||[];c.toString=function(b){var a="mixpanel";"mixpanel"!==d&&(a+="."+d);b||(a+=" (stub)");return a};c.people.toString=function(){return c.toString(1)+".people (stub)"};i="disable time_event track track_pageview track_links track_forms register register_once alias unregister identify name_tag set_config people.set people.set_once people.increment people.append people.union people.track_charge people.clear_charges people.delete_user".split(" ");
+for(g=0;g<i.length;g++)f(c,i[g]);b._i.push([a,e,d])};b.__SV=1.2;a=e.createElement("script");a.type="text/javascript";a.async=!0;a.src="undefined"!==typeof MIXPANEL_CUSTOM_LIB_URL?MIXPANEL_CUSTOM_LIB_URL:"file:"===e.location.protocol&&"//cdn.mxpnl.com/libs/mixpanel-2-latest.min.js".match(/^\/\//)?"https://cdn.mxpnl.com/libs/mixpanel-2-latest.min.js":"//cdn.mxpnl.com/libs/mixpanel-2-latest.min.js";f=e.getElementsByTagName("script")[0];f.parentNode.insertBefore(a,f)}})(document,window.mixpanel||[]);
+mixpanel.init("{{site.mixpanel}}");</script>
+

--- a/src/jekyll/_layouts/default.html
+++ b/src/jekyll/_layouts/default.html
@@ -10,16 +10,47 @@
     <script src="https://js.shubox.io/v1/{{ site.shuboxScriptId }}_src.js"></script>
     <script src="https://use.typekit.net/uma1wda.js"></script>
     <script>try{ Typekit.load({ async: true  }); }catch(e){}</script>
+
+
+    <!-- Facebook -->
+    <script>
+    !function(f,b,e,v,n,t,s){if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+    n.callMethod.apply(n,arguments):n.queue.push(arguments)};if(!f._fbq)f._fbq=n;
+    n.push=n;n.loaded=!0;n.version='2.0';n.queue=[];t=b.createElement(e);t.async=!0;
+    t.src=v;s=b.getElementsByTagName(e)[0];s.parentNode.insertBefore(t,s)}(window,
+    document,'script','https://connect.facebook.net/en_US/fbevents.js');
+    fbq(
+      'init',
+      '{{site.fb_pixel}}',
+      { em: 'insert_email_variable,' }
+    );
+    fbq('track', 'PageView');
+    </script>
+    <noscript><img height="1" width="1" style="display:none" src="https://www.facebook.com/tr?id={{site.fb_pixel}}&ev=PageView&noscript=1" /></noscript>
+
+    <!-- Google Analytics -->
+    <script>
+    window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+    ga('create', '{{site.ga}}', 'auto');
+    ga('send', 'pageview');
+    </script>
+    <script async src='https://www.google-analytics.com/analytics.js'></script>
+
+    <!-- Mixpanel -->
+    <script>(function(e,b){if(!b.__SV){var a,f,i,g;window.mixpanel=b;b._i=[];b.init=function(a,e,d){function f(b,h){var a=h.split(".");2==a.length&&(b=b[a[0]],h=a[1]);b[h]=function(){b.push([h].concat(Array.prototype.slice.call(arguments,0)))}}var c=b;"undefined"!==typeof d?c=b[d]=[]:d="mixpanel";c.people=c.people||[];c.toString=function(b){var a="mixpanel";"mixpanel"!==d&&(a+="."+d);b||(a+=" (stub)");return a};c.people.toString=function(){return c.toString(1)+".people (stub)"};i="disable time_event track track_pageview track_links track_forms register register_once alias unregister identify name_tag set_config people.set people.set_once people.increment people.append people.union people.track_charge people.clear_charges people.delete_user".split(" ");
+    for(g=0;g<i.length;g++)f(c,i[g]);b._i.push([a,e,d])};b.__SV=1.2;a=e.createElement("script");a.type="text/javascript";a.async=!0;a.src="undefined"!==typeof MIXPANEL_CUSTOM_LIB_URL?MIXPANEL_CUSTOM_LIB_URL:"file:"===e.location.protocol&&"//cdn.mxpnl.com/libs/mixpanel-2-latest.min.js".match(/^\/\//)?"https://cdn.mxpnl.com/libs/mixpanel-2-latest.min.js":"//cdn.mxpnl.com/libs/mixpanel-2-latest.min.js";f=e.getElementsByTagName("script")[0];f.parentNode.insertBefore(a,f)}})(document,window.mixpanel||[]);
+    mixpanel.init("{{site.mixpanel}}");</script>
+
   </head>
   <body>
-    
+
     {% include svg.html %}
     {% include header.liquid %}
     <main>
       {{ content }}
     </main>
     {% include footer.liquid %}
-    
+
     <script type="text/javascript" src="/js/_vendor/highlight.pack.js"></script>
     <script type="text/javascript" src="/js/_vendor/jquery-3.0.0.min.js"></script>
     <script type="text/javascript" src="/js/main.js"></script>

--- a/src/jekyll/_layouts/default.html
+++ b/src/jekyll/_layouts/default.html
@@ -10,37 +10,7 @@
     <script src="https://js.shubox.io/v1/{{ site.shuboxScriptId }}_src.js"></script>
     <script src="https://use.typekit.net/uma1wda.js"></script>
     <script>try{ Typekit.load({ async: true  }); }catch(e){}</script>
-
-
-    <!-- Facebook -->
-    <script>
-    !function(f,b,e,v,n,t,s){if(f.fbq)return;n=f.fbq=function(){n.callMethod?
-    n.callMethod.apply(n,arguments):n.queue.push(arguments)};if(!f._fbq)f._fbq=n;
-    n.push=n;n.loaded=!0;n.version='2.0';n.queue=[];t=b.createElement(e);t.async=!0;
-    t.src=v;s=b.getElementsByTagName(e)[0];s.parentNode.insertBefore(t,s)}(window,
-    document,'script','https://connect.facebook.net/en_US/fbevents.js');
-    fbq(
-      'init',
-      '{{site.fb_pixel}}',
-      { em: 'insert_email_variable,' }
-    );
-    fbq('track', 'PageView');
-    </script>
-    <noscript><img height="1" width="1" style="display:none" src="https://www.facebook.com/tr?id={{site.fb_pixel}}&ev=PageView&noscript=1" /></noscript>
-
-    <!-- Google Analytics -->
-    <script>
-    window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
-    ga('create', '{{site.ga}}', 'auto');
-    ga('send', 'pageview');
-    </script>
-    <script async src='https://www.google-analytics.com/analytics.js'></script>
-
-    <!-- Mixpanel -->
-    <script>(function(e,b){if(!b.__SV){var a,f,i,g;window.mixpanel=b;b._i=[];b.init=function(a,e,d){function f(b,h){var a=h.split(".");2==a.length&&(b=b[a[0]],h=a[1]);b[h]=function(){b.push([h].concat(Array.prototype.slice.call(arguments,0)))}}var c=b;"undefined"!==typeof d?c=b[d]=[]:d="mixpanel";c.people=c.people||[];c.toString=function(b){var a="mixpanel";"mixpanel"!==d&&(a+="."+d);b||(a+=" (stub)");return a};c.people.toString=function(){return c.toString(1)+".people (stub)"};i="disable time_event track track_pageview track_links track_forms register register_once alias unregister identify name_tag set_config people.set people.set_once people.increment people.append people.union people.track_charge people.clear_charges people.delete_user".split(" ");
-    for(g=0;g<i.length;g++)f(c,i[g]);b._i.push([a,e,d])};b.__SV=1.2;a=e.createElement("script");a.type="text/javascript";a.async=!0;a.src="undefined"!==typeof MIXPANEL_CUSTOM_LIB_URL?MIXPANEL_CUSTOM_LIB_URL:"file:"===e.location.protocol&&"//cdn.mxpnl.com/libs/mixpanel-2-latest.min.js".match(/^\/\//)?"https://cdn.mxpnl.com/libs/mixpanel-2-latest.min.js":"//cdn.mxpnl.com/libs/mixpanel-2-latest.min.js";f=e.getElementsByTagName("script")[0];f.parentNode.insertBefore(a,f)}})(document,window.mixpanel||[]);
-    mixpanel.init("{{site.mixpanel}}");</script>
-
+    {% include analytics.liquid %}
   </head>
   <body>
 

--- a/src/jekyll/_layouts/home.html
+++ b/src/jekyll/_layouts/home.html
@@ -19,7 +19,7 @@ layout: default
 
 <div class="features-block {% include tachyons-container.liquid %}">
   <div class="flex flex-wrap">
-    
+
     <div class="w-50 pa3">
       <img src="/assets/feature-upload.svg" alt="">
       <h2 class="f4 b dark-purple mb2">Direct Uploads</h2>
@@ -55,7 +55,7 @@ layout: default
         <h2 class="f4 b dark-purple mb2">Extract Frames from Animated Gifs</h2>
         <p class="gray lh-copy">Shubox doesn't flatten animated Gifs. Instead it gives you a static keyframe and retains the original in all it's glory.</p>
     </div>
-    
+
   </div>
 </div>
 
@@ -93,3 +93,7 @@ layout: default
 </div>
 
 {% include pricing.liquid %}
+
+<script>
+fbq('track', 'ViewContent', { page: 'Home page' });
+</script>

--- a/src/jekyll/_layouts/library.html
+++ b/src/jekyll/_layouts/library.html
@@ -20,8 +20,8 @@
         <span class="f5 gray">{{ page.title }}</span>
       </div>
     </header>
-    
+
     {{ content }}
-  
+
   </body>
 </html>

--- a/src/jekyll/_layouts/post.html
+++ b/src/jekyll/_layouts/post.html
@@ -7,11 +7,15 @@ layout: default
     <h1 class="f2 f1-ns b dark-purple lh-title">
       {{ page.title }}
     </h1>
-    <div class="nested-copy-line-height 
-      nested-headline-line-height 
-      nested-img 
+    <div class="nested-copy-line-height
+      nested-headline-line-height
+      nested-img
       nested-copy-colors">
       {{ content }}
     </div>
   </div>
 </div>
+
+<script>
+fbq('track', 'ViewContent', { page: 'Blog post', title: '{{ page.title }}' });
+</script>

--- a/src/jekyll/_posts/2016-07-15-first-post.md
+++ b/src/jekyll/_posts/2016-07-15-first-post.md
@@ -10,34 +10,39 @@ your end-users, or your internal team -- to upload images to S3. Let me unpack a
 
 Hi 👋, I'm [Joel]. I'm the founder of shubox.io. How are you?
 
-It's been several months since I shared anything about shubox.io being something I was working on. I
-have spent the majority of my spare time this winter and spring working on so as many facets of the
-application and keeping my head down - I didn't think I had a whole lot to share. 
+It's been several months since I shared anything about shubox.io being
+something I was working on. I have spent the majority of my spare time this
+winter and spring working on so as many facets of the application and keeping
+my head down - I didn't think I had a whole lot to share.
 
-But now? I believe shubox is ready to flip the sign around to "open" and enthusiastically welcome
-everyone to the app - we're ready for business.
+But now? I believe shubox is ready to flip the sign around to "open" and
+enthusiastically welcome everyone to the app - we're ready for business.
 
 Let me first give some context as to what shubox.io will strive to be.
 
-I want it to be the easiest, quickest, and most painless way to allow your users -- whether they are
-your end-users, or your internal team -- to upload images to S3. Let me unpack a few points there.
-Yes - we are built with S3 specifically in mind. I am one of many who feel that as far as asset
-hosting is concerned - S3 is the beginning and end of the conversation. It's reliable, it's
-inexpensive for most use cases, and its ubiquitous. You have an S3 bucket or two to spare, right?
-You will be serving your files from your own S3 account. I believe that ownership of your assets is
-important. I don't want my files living in someone else's buckets. In addition - this allows shubox
-to keep our costs low. That is by no means a trivial point 😄.
+I want it to be the easiest, quickest, and most painless way to allow your
+users -- whether they are your end-users, or your internal team -- to upload
+images to S3. Let me unpack a few points there.  Yes - we are built with S3
+specifically in mind. I am one of many who feel that as far as asset hosting is
+concerned - S3 is the beginning and end of the conversation. It's reliable,
+it's inexpensive for most use cases, and its ubiquitous. You have an S3 bucket
+or two to spare, right?  You will be serving your files from your own S3
+account. I believe that ownership of your assets is important. I don't want my
+files living in someone else's buckets. In addition - this allows shubox to
+keep our costs low. That is by no means a trivial point 😄.
 
-To start out, shubox will be focusing on images as our main asset. I can certainly see this evolving
-to something that may accept PDF's and do some fancy OCR. Don't hold me to it! But there are still
-aspirations.
+To start out, shubox will be focusing on images as our main asset. I can
+certainly see this evolving to something that may accept PDF's and do some
+fancy OCR. Don't hold me to it! But there are still aspirations.
 
-I believe that the tools and the infrastructure closely aligns with what web developers are
-utilizing today. These are the tools *I*, and many around me, have reached for, consistently, for years.
+I believe that the tools and the infrastructure closely aligns with what web
+developers are utilizing today. These are the tools *I*, and many around me,
+have reached for, consistently, for years.
 
-Considering the above points - I would like you to ask yourself "Does my, or my client's app, accept
-image uploads? Are uploads taking too long? Are uploads taking up too much of our server
-resources? Are you too often fiddling with code around all your file uploads?"
+Considering the above points - I would like you to ask yourself "Does my, or my
+client's app, accept image uploads? Are uploads taking too long? Are uploads
+taking up too much of our server resources? Are you too often fiddling with
+code around all your file uploads?"
 
 If so - I really think shubox can help you! Go ahead - [give it a shot]!
 

--- a/src/jekyll/_production_config.yml
+++ b/src/jekyll/_production_config.yml
@@ -1,0 +1,4 @@
+# Production analytics settings
+fb_pixel: "1498857493513730"
+ga: "UA-80905075-2"
+mixpanel: "2ee7e1ffc8256371236f9fc1a256c35b"

--- a/src/jekyll/blog/index.html
+++ b/src/jekyll/blog/index.html
@@ -6,7 +6,7 @@ layout: default
 
 <div class="{% include tachyons-container.liquid %}">
   <div class="flex flex-row flex-wrap nl2 nr2">
-    
+
     {% for post in site.posts %}
       <article class="w-100 w-50-m w-third-l mb5 ph2">
         <a href="{{ post.url }}">
@@ -20,7 +20,11 @@ layout: default
           </p>
         </a>
       </article>
-    {% endfor %}      
-    
+    {% endfor %}
+
   </div>
 </div>
+
+<script>
+fbq('track', 'ViewContent', { page: 'Blog index' });
+</script>

--- a/src/jekyll/demos/index.html
+++ b/src/jekyll/demos/index.html
@@ -6,9 +6,9 @@ layout: default
 
 <div class="{% include tachyons-container.liquid %}">
   <div class="flex-l flex-row">
-    
+
     <div class="subnav w5 mr4 mb5 flex-none">
-      <nav id="sticky" class="is-active">      
+      <nav id="sticky" class="is-active">
         <ul class="list pl0 ma0 bt bw2 b--light-gray pt4">
           <li class="mb3"><a href="#demo-easy-avatar">Upload an avatar</a></li>
           <li class="mb3"><a href="#demo-fancy-avatar">Another avatar upload approach</a></li>
@@ -18,12 +18,12 @@ layout: default
         </ul>
       </nav>
     </div>
-    
+
     <div class="w-auto">
       <div class="nested-copy-line-height nested-headline-line-height nested-img nested-copy-colors">
-        
+
         <div class="content-demo-container" id="demo-easy-avatar">
-          
+
           <div class="pv2 ph4 bg-light-purple">
             <p>
               Note that the Codepen demos pull in only 3 dependencies outside of the demo code:
@@ -164,10 +164,14 @@ layout: default
         </div>
 
         <div class="content-demo-area" id="demo-upload-webhook"></div>
-        
+
       </div>
     </div>
   </div>
 </div>
 
 <script async src="https://production-assets.codepen.io/assets/embed/ei.js"></script>
+
+<script>
+fbq('track', 'ViewContent', { page: 'Demos' });
+</script>

--- a/tasks/gulp/jekyll.js
+++ b/tasks/gulp/jekyll.js
@@ -8,20 +8,28 @@ const changed = require('gulp-changed')
 // ============================================================
 // Build Jekyll, Build!
 // ============================================================
+
+var build_command = [
+  'exec',
+  'jekyll',
+  'build',
+  '--source',
+  config.shuboxWeb.jekyll.src,
+  '--destination',
+  'tmp'
+]
+
+if (process.env.PRODUCTION_BUILD == 'true') {
+  build_command.push(
+    '--config',
+    'src/jekyll/_config.yml,src/jekyll/_production_config.yml'
+  )
+}
+
 gulp.task('jekyll-build', (done) => {
-  return cp.spawn(
-    'bundle',
-    [
-      'exec',
-      'jekyll',
-      'build',
-      '--source',
-      config.shuboxWeb.jekyll.src,
-      '--destination',
-      'tmp'
-    ],
-    { stdio: 'inherit' }
-  ).on('close', done)
+  return cp
+    .spawn('bundle', build_command, { stdio: 'inherit' })
+    .on('close', done)
 })
 
 // ============================================================


### PR DESCRIPTION
This is only slightly important.

...

Anyway, for the facebook and google adwords campaigns we'll need those to out
of the gate. Mixpanel is for personal preference as it is the least confusing
of all the options (in my opinion).

Since we'll have production and dev/staging versions of the site it's good to
not pollute the data in the production environments with extra data. Therefore
when the gulp jekyll task sees that PRODUCTION_BUILD is set to true it will
override the default config with the contents of _production_config.yml. This
is handy in that we can tell things like the analytics trackers what ID's to
use when things are built for productionand sent up to S3.